### PR TITLE
Make assembler script work with GCC 7.5.0

### DIFF
--- a/assembler/asm
+++ b/assembler/asm
@@ -31,7 +31,7 @@ rm $romfile 2> /dev/null
 # inserts lines starting with a '#' which the assembler doest
 # not like, these are subsequently removed with sed.
 #
-gcc -E $1 | sed '/^#.*/d' > $temp_file
+gcc -E -x c $1 | sed '/^#.*/d' > $temp_file
 
 $assembler $temp_file $destination
 if [ $? -ne 0 ]


### PR DESCRIPTION
When running this script using GCC 7.5.0, the compiler gives the warning 

```
gcc: warning: monitor.asm: linker input file unused because linking not done
```

and the script produces no output, causing the build to fail.

This is because the gcc frontend examines the filename "monitor.asm" and interprets it as an object file to be fed straight into linking. Any file name with no recognized suffix is treated this way.

The proposed change forces the gcc frontend to interpret the input file as a C file, thus invoking the pre-processor as expected.