### PR TITLE
missing type added

### DIFF
--- a/c/vasm/cond.c
+++ b/c/vasm/cond.c
@@ -8,7 +8,7 @@ int clev;  /* conditional level */
 static char cond[MAXCONDLEV+1];
 static char *condsrc[MAXCONDLEV+1];
 static int condline[MAXCONDLEV+1];
-static ifnesting;
+static int ifnesting;
 
 
 /* initialize conditional assembly */


### PR DESCRIPTION
compiler complained about "ifnesting" defaulting to an int due to lack of explicit type declaration. I believe it can safely be fixed directly in master.