### PR TITLE
uart_status definition removed from header

### DIFF
--- a/emulator/uart.h
+++ b/emulator/uart.h
@@ -55,7 +55,7 @@ typedef struct uart
 #define RESET_OUTPUT_PORT 15
 
 //flag to ensure restoring a working terminal when closing the emulator by closing the SDL window
-enum uart_status_t {uart_undef, uart_init, uart_rundown} uart_status;
+enum uart_status_t {uart_undef, uart_init, uart_rundown};
 
 unsigned int uart_read_register(uart *, unsigned int);
 void uart_write_register(uart *, unsigned int, unsigned int);


### PR DESCRIPTION
presence of this definition causes a multiple definitions error during compilation